### PR TITLE
feat: add Base64 encode/decode tool

### DIFF
--- a/e2e/fixtures/test-data.ts
+++ b/e2e/fixtures/test-data.ts
@@ -10,6 +10,7 @@ export const tools = [
   { name: "Markdown Preview", path: "/markdown-preview" },
   { name: "JavaScript Sandbox", path: "/js-sandbox" },
   { name: "Escape/Unescape Newlines", path: "/escape-newlines" },
+  { name: "Base64 Encode/Decode", path: "/base64-encode-decode" },
 ] as const;
 
 export const testData = {
@@ -70,4 +71,7 @@ This is a multi-line string.
 It has three distinct lines.`,
 
   escapedText: `Hello World!\\nThis is a multi-line string.\\nIt has three distinct lines.`,
+
+  base64TextToEncode: "Hello World! This is a test.",
+  base64EncodedText: "SGVsbG8gV29ybGQhIFRoaXMgaXMgYSB0ZXN0Lg==",
 };

--- a/e2e/tests/tools/base64-encode-decode.spec.ts
+++ b/e2e/tests/tools/base64-encode-decode.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "../../fixtures/test-fixtures";
+import { testData } from "../../fixtures/test-data";
+
+test.describe("Base64 Encode/Decode", { tag: ["@tools"] }, () => {
+  test.beforeEach(async ({ toolPage }) => {
+    await toolPage.goto("/base64-encode-decode");
+  });
+
+  test("page loads correctly and example/clear work", async ({ toolPage }) => {
+    // Initial state
+    await expect(toolPage.pageTitle).toHaveText("Base64 Encode/Decode");
+    await expect(toolPage.outputTextarea).toHaveValue("");
+
+    // Example loads data
+    await toolPage.loadExample();
+    await expect(toolPage.outputTextarea).not.toHaveValue("");
+
+    // Clear resets
+    await toolPage.clear();
+    await expect(toolPage.inputTextarea).toHaveValue("");
+    await expect(toolPage.outputTextarea).toHaveValue("");
+  });
+
+  test("encode mode encodes text to Base64", async ({ toolPage, page }) => {
+    await page.getByRole("radio", { name: "Encode" }).click();
+    await toolPage.setInput(testData.base64TextToEncode);
+    const output = await toolPage.getOutput();
+    expect(output).toBe(testData.base64EncodedText);
+  });
+
+  test("decode mode decodes Base64 to text", async ({ toolPage, page }) => {
+    await page.getByRole("radio", { name: "Decode" }).click();
+    await toolPage.setInput(testData.base64EncodedText);
+    const output = await toolPage.getOutput();
+    expect(output).toBe(testData.base64TextToEncode);
+  });
+
+  test("mode toggle switches between encode and decode", async ({
+    toolPage,
+    page,
+  }) => {
+    await page.getByRole("radio", { name: "Encode" }).click();
+    await toolPage.setInput("Hello World");
+    const encoded = await toolPage.getOutput();
+    expect(encoded).toContain("SGVsbG8gV29ybGQ=");
+
+    await page.getByRole("radio", { name: "Decode" }).click();
+    await toolPage.setInput(encoded);
+    const decoded = await toolPage.getOutput();
+    expect(decoded).toBe("Hello World");
+  });
+
+  test("swap button swaps input and output and toggles mode", async ({
+    toolPage,
+    page,
+  }) => {
+    // Start in encode mode
+    await page.getByRole("radio", { name: "Encode" }).click();
+    await toolPage.setInput(testData.base64TextToEncode);
+    const encodedOutput = await toolPage.getOutput();
+    expect(encodedOutput).toBe(testData.base64EncodedText);
+
+    // Click swap button
+    await page.getByTestId("btn-swap").click();
+
+    // Verify input now contains the encoded output
+    const newInput = await toolPage.inputTextarea.inputValue();
+    expect(newInput).toBe(encodedOutput);
+
+    // Verify mode switched to decode
+    await expect(page.getByRole("radio", { name: "Decode" })).toBeChecked();
+
+    // Verify output now shows decoded text
+    const newOutput = await toolPage.getOutput();
+    expect(newOutput).toBe(testData.base64TextToEncode);
+  });
+
+  test("swap button is disabled when output is empty", async ({ page }) => {
+    await expect(page.getByTestId("btn-swap")).toBeDisabled();
+  });
+
+  test("invalid Base64 in decode mode shows error", async ({
+    toolPage,
+    page,
+  }) => {
+    await page.getByRole("radio", { name: "Decode" }).click();
+    await toolPage.setInput("This is not valid base64!!!");
+    const output = await toolPage.getOutput();
+    expect(output).toContain("Error:");
+  });
+});

--- a/src/app/(tools)/base64-encode-decode/page.tsx
+++ b/src/app/(tools)/base64-encode-decode/page.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ClearButton } from "@/components/shared/clear-button";
+import { CopyButton } from "@/components/shared/copy-button";
+import { ActiveIcon } from "@/components/shared/active-icon";
+import { useToolState } from "@/hooks/use-tool-state";
+import { FileCode, ArrowLeftRight } from "lucide-react";
+
+type Mode = "encode" | "decode";
+
+const EXAMPLE_TEXT = "Hello World! This is a sample text for Base64 encoding.";
+const EXAMPLE_ENCODED = "SGVsbG8gV29ybGQhIFRoaXMgaXMgYSBzYW1wbGUgdGV4dCBmb3IgQmFzZTY0IGVuY29kaW5nLg==";
+
+export default function Base64EncodDecodePage() {
+  const { input, setInput, settings, setSetting, clear } = useToolState("/base64-encode-decode");
+  const mode = (settings.mode as Mode) || "encode";
+  const setMode = (value: Mode) => setSetting("mode", value);
+
+  const { output, error } = useMemo(() => {
+    if (!input) {
+      return { output: "", error: null };
+    }
+
+    try {
+      if (mode === "encode") {
+        // Encode to Base64
+        return { output: btoa(input), error: null };
+      } else {
+        // Decode from Base64
+        return { output: atob(input), error: null };
+      }
+    } catch (e) {
+      return {
+        output: "",
+        error: e instanceof Error ? e.message : "Invalid Base64 input",
+      };
+    }
+  }, [input, mode]);
+
+  const handleClear = () => {
+    clear();
+  };
+
+  const handleExample = () => {
+    setInput(mode === "encode" ? EXAMPLE_TEXT : EXAMPLE_ENCODED);
+  };
+
+  const handleModeChange = (value: string) => {
+    if (value) setMode(value as Mode);
+  };
+
+  const handleSwap = () => {
+    // Swap input and output, and toggle the mode
+    setInput(output);
+    setMode(mode === "encode" ? "decode" : "encode");
+  };
+
+  const selectedItemClass =
+    "data-[state=on]:!bg-primary data-[state=on]:!text-primary-foreground";
+
+  return (
+    <div className="flex flex-col h-full gap-4">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold tracking-tight">Base64 Encode/Decode</h1>
+        <p className="text-sm text-muted-foreground">
+          Encode text to Base64 or decode Base64 strings
+        </p>
+      </div>
+
+      <TooltipProvider>
+        <div className="flex flex-wrap items-center gap-4">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button data-testid="btn-example" variant="outline" onClick={handleExample}>
+                <FileCode className="h-4 w-4 mr-2" />
+                Example
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {mode === "encode" ? "Load sample text to encode" : "Load sample Base64 text"}
+            </TooltipContent>
+          </Tooltip>
+          <ClearButton onClick={handleClear} />
+          <ToggleGroup
+            type="single"
+            variant="outline"
+            value={mode}
+            onValueChange={handleModeChange}
+            className="justify-start"
+          >
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <ToggleGroupItem
+                  value="encode"
+                  aria-label="Encode"
+                  className={selectedItemClass}
+                >
+                  <ActiveIcon active={mode === "encode"} />
+                  Encode
+                </ToggleGroupItem>
+              </TooltipTrigger>
+              <TooltipContent>Convert text to Base64</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <ToggleGroupItem
+                  value="decode"
+                  aria-label="Decode"
+                  className={selectedItemClass}
+                >
+                  <ActiveIcon active={mode === "decode"} />
+                  Decode
+                </ToggleGroupItem>
+              </TooltipTrigger>
+              <TooltipContent>Convert Base64 back to text</TooltipContent>
+            </Tooltip>
+          </ToggleGroup>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                data-testid="btn-swap"
+                variant="outline"
+                onClick={handleSwap}
+                disabled={!output}
+              >
+                <ArrowLeftRight className="h-4 w-4 mr-2" />
+                Swap
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Swap input and output</TooltipContent>
+          </Tooltip>
+
+          <CopyButton text={output} showLabel className="ml-auto" />
+        </div>
+      </TooltipProvider>
+
+      <div className="grid grid-cols-2 gap-4 flex-1 min-h-0">
+        <div className="flex flex-col gap-2 min-h-0">
+          <label className="text-sm font-medium">
+            {mode === "encode" ? "Text to Encode" : "Base64 to Decode"}
+          </label>
+          <Textarea
+            data-testid="tool-input"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder={
+              mode === "encode"
+                ? "Enter text to encode..."
+                : "Enter Base64 string to decode..."
+            }
+            className={`h-0 flex-1 resize-none font-mono text-sm overflow-auto ${
+              error ? "border-red-500 focus-visible:ring-red-500" : ""
+            }`}
+          />
+        </div>
+
+        <div className="flex flex-col gap-2 min-h-0">
+          <label className="text-sm font-medium">
+            {mode === "encode" ? "Base64 Output" : "Decoded Output"}
+          </label>
+          <Textarea
+            data-testid="tool-output"
+            value={error ? `Error: ${error}` : output}
+            readOnly
+            placeholder={
+              mode === "encode"
+                ? "Base64 encoded text will appear here..."
+                : "Decoded text will appear here..."
+            }
+            className={`h-0 flex-1 resize-none font-mono text-sm overflow-auto bg-muted/50 ${
+              error ? "text-red-500" : ""
+            }`}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/tools-config.ts
+++ b/src/lib/tools-config.ts
@@ -8,6 +8,7 @@ import {
   FileText,
   Code2,
   WrapText,
+  Binary,
 } from "lucide-react";
 
 export const tools = [
@@ -76,6 +77,12 @@ export const tools = [
     path: "/escape-newlines",
     description: "Escape or unescape newline characters in text",
     icon: WrapText,
+  },
+  {
+    name: "Base64 Encode/Decode",
+    path: "/base64-encode-decode",
+    description: "Encode text to Base64 or decode Base64 strings",
+    icon: Binary,
   },
 ] as const;
 


### PR DESCRIPTION
- Implemented Base64 encode/decode tool with encode/decode modes
- Added swap button to swap input/output and toggle mode
- Added tool to tools-config.ts with Binary icon
- Added comprehensive E2E tests
- Follows existing pattern with state persistence via useToolState
- Includes example data and error handling for invalid Base64

Closes #6